### PR TITLE
Potential fix for code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/mock_api_server.py
+++ b/mock_api_server.py
@@ -347,7 +347,8 @@ def generate_stories():
         return success_response(result, "Instagram Stories generated successfully")
 
     except Exception as e:
-        return error_response(f"Stories generation failed: {str(e)}")
+        logging.error(f"Error during stories generation: {str(e)}", exc_info=True)
+        return error_response("Stories generation failed due to an internal error.")
 
 # Mock Instagram Post Endpoint
 @app.route('/instagram/post', methods=['POST'])
@@ -387,7 +388,8 @@ def instagram_post():
         return success_response(post_result, "Instagram post published successfully")
 
     except Exception as e:
-        return error_response(f"Instagram posting failed: {str(e)}")
+        logging.error(f"Error during Instagram posting: {str(e)}", exc_info=True)
+        return error_response("Instagram posting failed due to an internal error.")
 
 # Analytics Endpoint
 @app.route('/analytics', methods=['GET'])


### PR DESCRIPTION
Potential fix for [https://github.com/Gmpho/autmation-tasks/security/code-scanning/3](https://github.com/Gmpho/autmation-tasks/security/code-scanning/3)

To fix the issue, the application should avoid including the exception message (`str(e)`) in the response sent to the user. Instead, a generic error message should be returned, and the detailed exception information should be logged internally for debugging purposes. This ensures that sensitive information is not exposed to external users while still allowing developers to diagnose issues.

**Steps to implement the fix:**
1. Replace the usage of `str(e)` in the `error_response` calls with a generic error message.
2. Log the detailed exception information (e.g., stack trace) using the `logging` module.
3. Ensure that the `logging` module is properly configured to store logs securely.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
