### PR TITLE
Potential fix for code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/mock_api_server.py
+++ b/mock_api_server.py
@@ -414,7 +414,8 @@ def get_mcp_tools():
         tools = mcp_manager.get_available_tools()
         return success_response(tools, "MCP tools retrieved successfully")
     except Exception as e:
-        return error_response(f"Failed to get MCP tools: {str(e)}")
+        logging.error(f"Failed to get MCP tools: {str(e)}", exc_info=True)
+        return error_response("Failed to retrieve MCP tools due to an internal error.")
 
 @app.route('/mcp/<tool_name>', methods=['POST'])
 @security_middleware
@@ -437,7 +438,8 @@ def call_mcp_tool(tool_name):
     except ValueError as e:
         return error_response(str(e), 404)
     except Exception as e:
-        return error_response(f"MCP tool execution failed: {str(e)}")
+        logging.error(f"MCP tool execution failed: {str(e)}", exc_info=True)
+        return error_response("MCP tool execution failed due to an internal error.")
 
 # Specific MCP tool endpoints for easier n8n integration
 @app.route('/mcp/filesystem', methods=['POST'])


### PR DESCRIPTION
Potential fix for [https://github.com/Gmpho/autmation-tasks/security/code-scanning/3](https://github.com/Gmpho/autmation-tasks/security/code-scanning/3)

To fix the issue, we will modify the error handling logic to ensure that detailed exception messages, including stack traces, are not exposed to the user. Instead, we will log the detailed error message on the server for debugging purposes and return a generic error message to the user. This approach ensures that sensitive information is not leaked while still allowing developers to diagnose issues.

Specifically:
1. Replace the direct inclusion of `str(e)` in the `error_response` calls with a generic error message.
2. Log the detailed exception message and stack trace using the `logging` module for server-side debugging.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
