### PR TITLE
Potential fix for code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/mock_api_server.py
+++ b/mock_api_server.py
@@ -436,7 +436,8 @@ def call_mcp_tool(tool_name):
         return success_response(result, f"MCP tool '{tool_name}' executed successfully")
 
     except ValueError as e:
-        return error_response(str(e), 404)
+        logging.error(f"ValueError occurred: {str(e)}", exc_info=True)
+        return error_response("Invalid input provided.", 404)
     except Exception as e:
         logging.error(f"MCP tool execution failed: {str(e)}", exc_info=True)
         return error_response("MCP tool execution failed due to an internal error.")


### PR DESCRIPTION
Potential fix for [https://github.com/Gmpho/autmation-tasks/security/code-scanning/3](https://github.com/Gmpho/autmation-tasks/security/code-scanning/3)

To fix the issue, we need to ensure that sensitive information from exceptions is not exposed to external users. Instead of returning the raw exception message (`str(e)`) in the response, we should return a generic error message to the user while logging the detailed exception information on the server. This approach ensures that developers can debug issues using the logs without exposing sensitive details to users.

The changes involve:
1. Replacing the use of `str(e)` in the `error_response` call on line 439 with a generic error message.
2. Ensuring that the detailed exception information is logged using `logging.error` (already implemented on line 441).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
